### PR TITLE
兼容GNU GCC编译器

### DIFF
--- a/luatinker/lua_tinker.h
+++ b/luatinker/lua_tinker.h
@@ -448,7 +448,21 @@ namespace lua_tinker
 	{
 		V T::*_var;
 		mem_var(V T::*val) : _var(val) {}
-		void get(lua_State *L)	{ push<if_<is_obj<V>::value,V&,V>::type>(L, read<T*>(L,1)->*(_var));	}
+		void get(lua_State *L)
+		{
+		#if defined __GNUC__
+			if(is_obj<V>::value)
+			{
+				push<V&>(L,read<T*>(L,1)->*(_var));
+			}
+			else
+			{
+				push<V>(L,read<T*>(L,1)->*(_var));
+			}
+		#else
+			push<if_<is_obj<V>::value,VREF,V>::type>(L,read<T*>(L,1)->*(_var));
+		#endif
+		}
 		void set(lua_State *L)	{ read<T*>(L,1)->*(_var) = read<V>(L, 3);	}
 	};
 


### PR DESCRIPTION
is_obj<V>::value,VREF,V>::type 在GNU GCC编译器下不能正常使用is_obj模板获取到对应的类型
